### PR TITLE
add roadmap override check

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -30,6 +30,44 @@ function merge(source, target){
     return source;
 }
 
+function checkRoadmapPath(origin, roadmapPath, stack){
+
+    function getRoadmapPathSummary(roadmapPath){
+        var info = roadmapPath.map(function(c){
+            return c.reg;
+        }).slice(0, 5);
+        if (roadmapPath.length > 5){
+            info.push('...');
+        }
+        return info.join(', ');
+    }
+
+    function getStackInfo(stack){
+        var stacks = stack.split('\n');
+        if (stacks.length < 2){
+            return '';
+        }
+        //stacks[2] is the fis-conf stack
+        var fisConfStack = stacks[2];
+        var info = fisConfStack.match(/\((.*)\)/);
+        if (info.length < 1){
+            return '';
+        }
+        return ' at ' + info[1];
+    }
+
+    if (origin.roadmap && origin.roadmap.path){
+        fis.log.warning(
+            'roadmap.path [' +
+                getRoadmapPathSummary(origin.roadmap.path) +
+            '] was overrided by [' +
+                getRoadmapPathSummary(roadmapPath) +
+            ']' + getStackInfo(stack) +
+            ', please use fis.config.get(\'roadmap.path\').unshift(ruler) to add rulers.');
+        console.log()
+    }
+}
+
 var Config = Object.derive({
     constructor : function(){
         this.init.apply(this, arguments);
@@ -56,8 +94,17 @@ var Config = Object.derive({
     },
     set : function(path, value){
         if(typeof value === 'undefined'){
+            if (path.roadmap && path.roadmap.path){
+                checkRoadmapPath(this.data, path, (new Error()).stack);
+            }
             this.data = path;
         } else {
+            if (path === 'roadmap.path'){
+                checkRoadmapPath(this.data, value, (new Error()).stack);
+            }
+            if (path === 'roadmap' && value.path){
+                checkRoadmapPath(this.data, value.path, (new Error()).stack);
+            }
             path = String(path || '').trim();
             if(path){
                 var paths = path.split('.'),
@@ -70,7 +117,7 @@ var Config = Object.derive({
                     } else if(type === 'undefined'){
                         data = data[key] = {};
                     } else {
-                        fis.log.error('forbidden to set property[' + key + '] of [' + type + '] data');
+                        fis.log.error('forbidden to set property [' + key + '] of [' + type + '] data');
                     }
                 });
                 data[last] = value;
@@ -100,8 +147,12 @@ var Config = Object.derive({
     },
     merge : function(){
         var self = this;
+        var stack = (new Error()).stack;
         [].slice.call(arguments).forEach(function(arg){
             if(typeof arg === 'object'){
+                if (arg.roadmap && arg.roadmap.path){
+                    checkRoadmapPath(self.data, arg.roadmap.path, stack);
+                }
                 merge(self.data, arg);
             } else {
                 fis.log.warning('unable to merge data[' + arg + '].');


### PR DESCRIPTION
关联https://github.com/fex-team/fis/issues/299 效果如下

```
D:\Work\Code\test\override>fis release

 [WARNI] roadmap.path [**.css, **.js] was overrided by [**.css] at D:\Work\Code\
test\override\fis-conf.js:16:12, please use fis.config.get('roadmap.path').unshi
ft(ruler) to add rulers.


 [WARNI] roadmap.path [**.css, **.js] was overrided by [**.js] at D:\Work\Code\t
est\override\fis-conf.js:27:12, please use fis.config.get('roadmap.path').unshif
t(ruler) to add rulers.


 [WARNI] roadmap.path [**.js] was overrided by [**.js2] at D:\Work\Code\test\ove
rride\fis-conf.js:34:12, please use fis.config.get('roadmap.path').unshift(ruler
) to add rulers.
```