### PR TITLE
修正 https 部署问题

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -720,6 +720,7 @@ _.parseUrl = function(url, opt){
     opt = opt || {};
     url = Url.parse(url);
     var ssl = url.protocol === 'https:';
+    opt.protocol = url.protocol;
     opt.host = opt.host
         || opt.hostname
         || ((ssl || url.protocol === 'http:') ? url.hostname : 'localhost');


### PR DESCRIPTION
`upload` 和 `download` 会使用 `var http = opt.protocol === 'https:' ? require('https') : require('http');` 这样的语法判断引入的库

但是 `opt = _.parseUrl(url, opt);` 返回的没没有 `protocol`
