### PR TITLE
fix: fix fis.require package need 

### DIFF
--- a/fis-kernel.js
+++ b/fis-kernel.js
@@ -98,7 +98,10 @@ fis.require = function(){
                     filter: function(item){
                         return item.path.match(pluginName)
                     }
-                })[0].path;
+                });
+                projectModulePath = projectModulePath.length ? projectModulePath[0].path : void 0;
+                if(!projectModulePath)
+                    throw e;
                 path = require.resolve(projectModulePath);
                 return fis.require._cache[name] = require(projectModulePath);
             } catch (e) {

--- a/fis-kernel.js
+++ b/fis-kernel.js
@@ -5,6 +5,8 @@
 
 'use strict';
 
+var paths = require('path');
+var klawSync = require('klaw-sync');
 var last = Date.now();
 
 //oo
@@ -78,6 +80,7 @@ fis.require = function(){
     var name = Array.prototype.slice.call(arguments, 0).join('-');
     if(fis.require._cache.hasOwnProperty(name)) return fis.require._cache[name];
     var names = [];
+    var projectModulePath = void 0;
     for(var i = 0, len = fis.require.prefixes.length; i < len; i++){
         try {
             var pluginName = fis.require.prefixes[i] + '-' + name;
@@ -89,8 +92,19 @@ fis.require = function(){
                 fis.log.error('load plugin [' + pluginName + '] error : ' + e.message);
             }
         } catch (e){
-            if (e.code !== 'MODULE_NOT_FOUND') {
-                throw e;
+            try {
+                projectModulePath = klawSync(process.cwd(), {
+                    nofile:true,
+                    filter: function(item){
+                        return item.path.match(pluginName)
+                    }
+                })[0].path;
+                path = require.resolve(projectModulePath);
+                return fis.require._cache[name] = require(projectModulePath);
+            } catch (e) {
+                if (e.code !== 'MODULE_NOT_FOUND') {
+                    throw e;
+                }
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fis-kernel",
   "description": "fis kernel.",
-  "version": "2.0.19",
+  "version": "2.0.20",
   "author": "FIS Team <fis@baidu.com>",
   "homepage": "http://fis.baidu.com/",
   "license": "MIT",
@@ -20,8 +20,9 @@
     "test": "mocha test/ut"
   },
   "dependencies": {
-    "tar": "2.2.1",
-    "iconv-lite": "0.2.10"
+    "iconv-lite": "0.2.10",
+    "klaw-sync": "^3.0.2",
+    "tar": "2.2.1"
   },
   "devDependencies": {
     "chai": "1.9.1",


### PR DESCRIPTION
- node version: 6.7.0
- platform: macOS 10.12

- errors:  
 老的项目，在使用fis开发的时候，使用build.sh -s的时候，偶尔会提示如下错误：
```shell
[ERROR] unable to load plugin [fis-optimizer-php-template-compress]
```
此时需要全局安装相应的包才能解决（旧的工程目录下没有package.json, package.json 存放于_build文件夹中）。
- fixed:  
对`fis.require`添加判断，如果当前文件目录不存在node_modules，会扫描当前文件夹的目录，免去全局安装，只需在项目中具有package.json的目录下npm i [package]即可。require默认不会去_build文件夹下面搜索node_modules,通过klaw实现工程目录下的全局搜索。